### PR TITLE
fix(docsrs): migrate from `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! [`zerocopy::byteorder`]: https://docs.rs/zerocopy/0.7/zerocopy/byteorder/index.html
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 


### PR DESCRIPTION
`dock_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.